### PR TITLE
fix: enable build in Xcode 12 (for iOS >= 12)

### DIFF
--- a/RNHoleView.podspec
+++ b/RNHoleView.podspec
@@ -17,6 +17,6 @@ Pod::Spec.new do |s|
   s.requires_arc     = true
 #   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES' }
 
-  s.dependency 'React'
+  s.dependency 'React-Core'
 end
 


### PR DESCRIPTION
Updated react dependency in podspec to enable build in Xcode 12 (for iOS >= 12)
See [facebook/react-native#29633 (comment)](https://github.com/facebook/react-native/issues/29633#issuecomment-694187116)