### PR TITLE
Updating build settings

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,6 +1,6 @@
 
 buildscript {
-    ext.kotlin_version = '1.4.10'
+    ext.kotlin_version = '1.5.31'
 
     repositories {
         jcenter()

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,6 +1,6 @@
 
 buildscript {
-    ext.kotlin_version = '1.5.31'
+    ext.kotlin_version = safeExtGet('kotlin_version', '1.5.31')
 
     repositories {
         jcenter()

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-hole-view",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "Component to made an overlay with touch-through hole",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
In Order to eliminate some nasty kotlin warnings, it would be very nice to use the latest stable version or an externally defined kotlin version.