### PR TITLE
fix: use google maven repository first

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -3,8 +3,8 @@ buildscript {
     ext.kotlin_version = '1.4.10'
 
     repositories {
-        jcenter()
         google()
+        jcenter()
     }
 
     dependencies {


### PR DESCRIPTION
Resolve `Read timed out` error when trying to build app with the `react-native-hole-view` library.
```
A problem occurred configuring project ':react-native-hole-view'.
> Could not resolve all artifacts for configuration ':react-native-hole-view:classpath'.
   > Could not resolve com.android:signflinger:4.1.0.
     Required by:
         project :react-native-hole-view > com.android.tools.build:gradle:4.1.0 > com.android.tools.build:builder:4.1.0
      > Could not resolve com.android:signflinger:4.1.0.
         > Could not get resource 'https://jcenter.bintray.com/com/android/signflinger/4.1.0/signflinger-4.1.0.pom'.
            > Could not HEAD 'https://jcenter.bintray.com/com/android/signflinger/4.1.0/signflinger-4.1.0.pom'.
               > Read timed out
...
```
