### PR TITLE
fix: don't crash on iOS because of an `onClickBlock` in react-native 0.73.2

### DIFF
--- a/ios/RNHoleView/RNHoleViewImpl.h
+++ b/ios/RNHoleView/RNHoleViewImpl.h
@@ -43,4 +43,6 @@ typedef void(^AnimationFinishedCallback)();
 
 @property (nonatomic, copy) AnimationFinishedCallback onAnimationFinishedFabric;
 
+- (void)setOnClick:(void (^)(void))onClickBlock;
+
 @end

--- a/ios/RNHoleView/RNHoleViewImpl.m
+++ b/ios/RNHoleView/RNHoleViewImpl.m
@@ -28,7 +28,7 @@ andBorderBottomRightRadius:(CGFloat)borderBottomRightRadius
 	if (self) {
 		self.rect = CGRectMake(x, y, width, height);
 		self.borderRadius = borderRadius;
-		
+
 		self.borderTopLeftRadius = borderTopLeftRadius == DEFAULT_SPECIFIC_BORDER_RADIUS_VALUE ? borderRadius : borderTopLeftRadius;
 		self.borderTopRightRadius = borderTopRightRadius == DEFAULT_SPECIFIC_BORDER_RADIUS_VALUE ? borderRadius : borderTopRightRadius;
 		self.borderBottomLeftRadius = borderBottomLeftRadius == DEFAULT_SPECIFIC_BORDER_RADIUS_VALUE ? borderRadius : borderBottomLeftRadius;
@@ -50,6 +50,8 @@ andBorderBottomRightRadius:(CGFloat)borderBottomRightRadius
 
 @property (nonatomic) dispatch_source_t holesTimer;
 
+@property (nonatomic, copy) void (^onClickBlock)(void);
+
 @end
 
 @implementation RNHoleViewImpl
@@ -63,7 +65,7 @@ andBorderBottomRightRadius:(CGFloat)borderBottomRightRadius
 		_maskLayer.fillRule = kCAFillRuleEvenOdd;
 		_maskLayer.shouldRasterize = YES;
 		_maskLayer.rasterizationScale = [UIScreen mainScreen].scale;
-		
+
 		self.layer.mask = _maskLayer;
 	}
 	return self;
@@ -73,7 +75,7 @@ andBorderBottomRightRadius:(CGFloat)borderBottomRightRadius
 -(void)layoutSubviews
 {
 	_maskLayer.frame = CGRectMake(0, 0, self.frame.size.width, self.frame.size.height);
-	
+
 	[self setMaskPath:self.holePaths skipAnimation:YES];
 }
 
@@ -81,19 +83,19 @@ andBorderBottomRightRadius:(CGFloat)borderBottomRightRadius
 -(void)setHoles:(NSArray<NSDictionary *> *)holes
 {
 	NSMutableArray <RNHoleViewHole*> *parsedHoles = @[].mutableCopy;
-	
+
 	[holes enumerateObjectsUsingBlock:^(NSDictionary * _Nonnull obj, NSUInteger idx, BOOL * _Nonnull stop) {
 		BOOL isRTL = obj[@"isRTL"] && [obj[@"isRTL"] boolValue] == YES;
-		
+
 		CGFloat borderRadius = obj[@"borderRadius"] ? [obj[@"borderRadius"] floatValue] : DEFAULT_BORDER_RADIUS_VALUE;
 		CGFloat borderTopLeftRadius = obj[@"borderTopLeftRadius"] ? [obj[@"borderTopLeftRadius"] floatValue] : DEFAULT_SPECIFIC_BORDER_RADIUS_VALUE;
 		CGFloat borderTopRightRadius = obj[@"borderTopRightRadius"] ? [obj[@"borderTopRightRadius"] floatValue] : DEFAULT_SPECIFIC_BORDER_RADIUS_VALUE;
 		CGFloat borderBottomLeftRadius = obj[@"borderBottomLeftRadius"] ? [obj[@"borderBottomLeftRadius"] floatValue] : DEFAULT_SPECIFIC_BORDER_RADIUS_VALUE;
 		CGFloat borderBottomRightRadius = obj[@"borderBottomRightRadius"] ? [obj[@"borderBottomRightRadius"] floatValue] : DEFAULT_SPECIFIC_BORDER_RADIUS_VALUE;
-		
+
 		if(obj[@"borderTopStartRadius"]){
 			CGFloat value = [obj[@"borderTopStartRadius"] floatValue];
-			
+
 			if(value!=DEFAULT_SPECIFIC_BORDER_RADIUS_VALUE){
 				if(isRTL){
 					borderTopRightRadius = value;
@@ -102,10 +104,10 @@ andBorderBottomRightRadius:(CGFloat)borderBottomRightRadius
 				}
 			}
 		}
-		
+
 		if(obj[@"borderTopEndRadius"]){
 			CGFloat value = [obj[@"borderTopEndRadius"] floatValue];
-			
+
 			if(value!=DEFAULT_SPECIFIC_BORDER_RADIUS_VALUE){
 				if(isRTL){
 					borderTopLeftRadius = value;
@@ -114,10 +116,10 @@ andBorderBottomRightRadius:(CGFloat)borderBottomRightRadius
 				}
 			}
 		}
-		
+
 		if(obj[@"borderBottomStartRadius"]){
 			CGFloat value = [obj[@"borderBottomStartRadius"] floatValue];
-			
+
 			if(value!=DEFAULT_SPECIFIC_BORDER_RADIUS_VALUE){
 				if(isRTL){
 					borderBottomRightRadius = value;
@@ -126,10 +128,10 @@ andBorderBottomRightRadius:(CGFloat)borderBottomRightRadius
 				}
 			}
 		}
-		
+
 		if(obj[@"borderBottomEndRadius"]){
 			CGFloat value = [obj[@"borderBottomEndRadius"] floatValue];
-			
+
 			if(value!=DEFAULT_SPECIFIC_BORDER_RADIUS_VALUE){
 				if(isRTL){
 					borderBottomLeftRadius = value;
@@ -138,23 +140,23 @@ andBorderBottomRightRadius:(CGFloat)borderBottomRightRadius
 				}
 			}
 		}
-		
+
 		RNHoleViewHole *hole = [[RNHoleViewHole alloc] initWitnX:[obj[@"x"] floatValue] y:[obj[@"y"] floatValue] width:[obj[@"width"] floatValue] height:[obj[@"height"] floatValue] andBorderRadius:borderRadius andBorderTopLeftRadius:borderTopLeftRadius andBorderTopRightRadius:borderTopRightRadius andBorderBottomLeftRadius:borderBottomLeftRadius andBorderBottomRightRadius:borderBottomRightRadius];
-		
+
 		[parsedHoles addObject:hole];
 	}];
-	
+
 	self.parsedHoles = parsedHoles;
 }
 
 
 -(void)setAnimation:(NSDictionary *)animation{
 	_animation = animation;
-	
+
 	if(_animation){
 		_animationDuration = animation[@"duration"];
 		NSString *timingFunction = animation[@"timingFunction"];
-	
+
 		if([timingFunction isEqualToString:@"LINEAR"]){
 			_animationTimingFunction =  [CAMediaTimingFunction functionWithName:kCAMediaTimingFunctionLinear];
 		}else if([timingFunction isEqualToString:@"EASE_IN"]){
@@ -164,7 +166,7 @@ andBorderBottomRightRadius:(CGFloat)borderBottomRightRadius
 		}else if([timingFunction isEqualToString:@"EASE_IN_OUT"]){
 			_animationTimingFunction =  [CAMediaTimingFunction functionWithName:kCAMediaTimingFunctionEaseInEaseOut];
 		}
-		
+
 	}
 }
 
@@ -172,20 +174,20 @@ andBorderBottomRightRadius:(CGFloat)borderBottomRightRadius
 -(void)setParsedHoles:(NSArray<RNHoleViewHole *> *)parsedHoles
 {
 	_parsedHoles = parsedHoles;
-	
+
 	[self stopHolesTimer];
-	
+
 	dispatch_source_t timer = dispatch_source_create(DISPATCH_SOURCE_TYPE_TIMER, 0, 0,  dispatch_get_main_queue());
-	
+
 	if ( timer ) {
 		dispatch_source_set_timer(timer, dispatch_time(DISPATCH_TIME_NOW, 0.01 * NSEC_PER_SEC), 0.01 * NSEC_PER_SEC, (1ull * NSEC_PER_SEC) / 10);
 		dispatch_source_set_event_handler(timer, ^(){
 			[self stopHolesTimer];
-			
+
 			[self setMaskPath:self.holePaths skipAnimation:NO];
 		});
 		dispatch_resume(timer);
-		
+
 		_holesTimer = timer;
 	}
 }
@@ -202,14 +204,14 @@ andBorderBottomRightRadius:(CGFloat)borderBottomRightRadius
 
 -(void)setMaskPath:(UIBezierPath *)maskPath skipAnimation:(BOOL)skipAnimation{
 	UIBezierPath *oldPath = _maskPath;
-	
+
 	_maskPath = maskPath;
-	
+
 	if(!skipAnimation && self.animation){
 		[_maskLayer removeAnimationForKey:@"path"];
-		
+
 		CABasicAnimation *pathAnimation = [CABasicAnimation new];
-		
+
 		pathAnimation.duration = _animationDuration.doubleValue/1000.0;
 		pathAnimation.keyPath = @"path";
 		pathAnimation.fromValue = oldPath ? (id)oldPath.CGPath : (id)_maskLayer.path;
@@ -218,34 +220,34 @@ andBorderBottomRightRadius:(CGFloat)borderBottomRightRadius
 		pathAnimation.fillMode = kCAFillModeForwards;
 		pathAnimation.timingFunction = _animationTimingFunction;
 		pathAnimation.delegate = self;
-		
+
 		[_maskLayer addAnimation:pathAnimation forKey:@"path"];
 	}else{
 		_maskLayer.path = _maskPath.CGPath;
 	}
-	
+
 }
 
 - (UIBezierPath *)holePaths
 {
 	UIBezierPath *currentPath = [UIBezierPath new];
 	currentPath.usesEvenOddFillRule = YES;
-	
+
 	[_parsedHoles enumerateObjectsUsingBlock:^(RNHoleViewHole *hole, NSUInteger idx, BOOL *_Nonnull stop) {
 		CGRect rect = hole.rect;
-		
+
 		UIBezierPath *path = [UIBezierPath new];
-		
+
 		[path addArcWithCenter:CGPointMake(rect.origin.x+rect.size.width-hole.borderTopRightRadius, rect.origin.y+hole.borderTopRightRadius) radius:hole.borderTopRightRadius startAngle:degreesToRadians(-90.f) endAngle:degreesToRadians(0.f)  clockwise:YES];
 		[path addArcWithCenter:CGPointMake(rect.origin.x+rect.size.width-hole.borderBottomRightRadius, rect.origin.y+rect.size.height-hole.borderBottomRightRadius) radius:hole.borderBottomRightRadius startAngle:degreesToRadians(0.f) endAngle:degreesToRadians(90.f)  clockwise:YES];
 		[path addArcWithCenter:CGPointMake(rect.origin.x+hole.borderBottomLeftRadius, rect.origin.y+rect.size.height-hole.borderBottomLeftRadius) radius:hole.borderBottomLeftRadius startAngle:degreesToRadians(90.f) endAngle:degreesToRadians(180.f)  clockwise:YES];
 		[path addArcWithCenter:CGPointMake(rect.origin.x+hole.borderTopLeftRadius, rect.origin.y+hole.borderTopLeftRadius) radius:hole.borderTopLeftRadius startAngle:degreesToRadians(180.f) endAngle:degreesToRadians(270.f)  clockwise:YES];
-		
+
 		[currentPath appendPath:path];
 	}];
-	
+
 	[currentPath appendPath:[UIBezierPath bezierPathWithRect:CGRectMake(0.0, 0.0, self.frame.size.width, self.frame.size.height)]];
-	
+
 	return currentPath;
 }
 
@@ -255,9 +257,9 @@ andBorderBottomRightRadius:(CGFloat)borderBottomRightRadius
 	if ( [self pointInRects:point] || !self.userInteractionEnabled) {
 		return NO;
 	}
-	
+
 	BOOL superPoint = [super pointInside:point withEvent:event];
-	
+
 	return superPoint;
 }
 
@@ -265,11 +267,11 @@ andBorderBottomRightRadius:(CGFloat)borderBottomRightRadius
 - (BOOL)pointInRects:(CGPoint)point
 {
 	__block BOOL pointInPath = NO;
-	
+
 	if (!CGPathContainsPoint(self.maskPath.CGPath, nil, point, YES) ) {
 		pointInPath = YES;
 	}
-	
+
 	return pointInPath;
 }
 
@@ -282,6 +284,17 @@ andBorderBottomRightRadius:(CGFloat)borderBottomRightRadius
             self.onAnimationFinishedFabric();
         }
 	}
+}
+
+- (void)setOnClick:(void (^)(void))onClickBlock {
+    _onClickBlock = onClickBlock;
+    [self addGestureRecognizer:[[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(handleTap)]];
+}
+
+- (void)handleTap {
+    if (self.onClickBlock) {
+        self.onClickBlock();
+    }
 }
 
 @end


### PR DESCRIPTION
When upgrading `react-native` to `0.73.2` for our project we faced this crash which did not happen in `react-native` version `0.72.5`
ref -> https://github.com/status-im/status-mobile/pull/18563#issuecomment-1907414008

This PR fixes that crash by modifying `RNHoleViewImpl` interface to accept `setOnClick`
This is a very basic implementation just so that we avoid the crash without having to change the way we use `react-native-hole-view` in our codebase.

If you would like this to be done some other way I would be happy to incorporate any feedback you have.

Looking forward to your thoughts on this @stephenkopylov 