### PR TITLE
Specify namespace in build.gradle instead of manifest's package

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -28,6 +28,7 @@ def safeExtGet(prop, fallback) {
 }
 
 android {
+    namespace 'com.ibitcy.react_native_hole_view'
     compileSdkVersion safeExtGet('compileSdkVersion', 29)
     buildToolsVersion safeExtGet('buildToolsVersion', '29.0.2')
 

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,4 +1,1 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.ibitcy.react_native_hole_view">
-
-</manifest>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" />


### PR DESCRIPTION
## Issue

- Since API 34(Android), namespace property must be specified in build.gradle's `android` block.  So this update contains migration of notation of package from `AndroidManifest.xml` to `build.gradle`