### PR TITLE
Install Module Dependencies for iOS for new arch as recommended by Meta

### DIFF
--- a/react-native-hole-view.podspec
+++ b/react-native-hole-view.podspec
@@ -2,8 +2,6 @@ require 'json'
 
 package = JSON.parse(File.read(File.join(__dir__, "package.json")))
 
-folly_flags = '-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1 -Wno-comma -Wno-shorten-64-to-32'
-
 Pod::Spec.new do |s|
   s.name         = "react-native-hole-view"
   s.version      = package['version']
@@ -19,18 +17,6 @@ Pod::Spec.new do |s|
   s.dependency 'React-Core'
 
   if ENV["RCT_NEW_ARCH_ENABLED"] == "1"
-    s.compiler_flags = folly_flags + " -DRCT_NEW_ARCH_ENABLED=1"
-    s.pod_target_xcconfig    = {
-      "HEADER_SEARCH_PATHS" => "\"$(PODS_ROOT)/boost\"",
-      "OTHER_CPLUSPLUSFLAGS" => "-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1",
-      "CLANG_CXX_LANGUAGE_STANDARD" => "c++17"
-    }
-    s.dependency "React-Codegen"
-    s.dependency "React-RCTFabric"
-    s.dependency "RCT-Folly"
-    s.dependency "RCTRequired"
-    s.dependency "RCTTypeSafety"
-    s.dependency "ReactCommon/turbomodule/core"
+    install_modules_dependencies(s)
   end
 end
-


### PR DESCRIPTION
Small PR making the code work correctly on new arch on iOS by using recommended by Meta `install_modules_dependencies` function