### PR TITLE
chore: add support for flexible page sizes

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -36,6 +36,11 @@ android {
         minSdkVersion safeExtGet('minSdkVersion', 21)
         targetSdkVersion safeExtGet('targetSdkVersion', 29)
         buildConfigField "boolean", "IS_NEW_ARCHITECTURE_ENABLED", isNewArchitectureEnabled().toString()
+        externalNativeBuild {
+            cmake {
+                arguments "-DANDROID_SUPPORT_FLEXIBLE_PAGE_SIZES=ON"
+            }
+        }
     }
     lintOptions {
         abortOnError false


### PR DESCRIPTION
Android 15 introduces support for devices with a 16 KB memory page size, which can cause runtime issues in apps that assume the default 4 KB page size.

This PR adds compatibility for 16 KB page sizes on Android 15 and above.