### PR TITLE
Android (newarch): fix return type mismatch by returning MutableMap (Fixes #44)

### DIFF
--- a/android/src/newarch/com/ibitcy/react_native_hole_view/RNHoleViewManager.kt
+++ b/android/src/newarch/com/ibitcy/react_native_hole_view/RNHoleViewManager.kt
@@ -42,12 +42,15 @@ class RNHoleViewManager(val reactContext: ReactApplicationContext): ViewGroupMan
 
     override fun getExportedCustomBubblingEventTypeConstants(): MutableMap<String, Any> {
         return MapBuilder.builder<String, Any>()
-                .put("topAnimationFinished", MapBuilder.of(
-                        "phasedRegistrationNames",
-                        MapBuilder.of<Any, Any>("bubbled", RNHoleViewManagerImpl.ON_ANIMATION_FINISHED)
-                    )
+            .put(
+                "topAnimationFinished",
+                MapBuilder.of(
+                    "phasedRegistrationNames",
+                    MapBuilder.of<Any, Any>("bubbled", RNHoleViewManagerImpl.ON_ANIMATION_FINISHED)
                 )
-                .build()
+            )
+            .build()
+            .toMutableMap()
     }
 
     @ReactProp(name = "animation")


### PR DESCRIPTION
### Summary
Fixes a Kotlin return-type mismatch in **newarch** manager: method signature expects `MutableMap<String, Any>` but `MapBuilder.build()` returns `Map<String, Any>`.

### Root Cause
`MapBuilder.build()` yields an immutable `Map`, causing:
> Return type mismatch: expected 'MutableMap<String, Any>', actual 'Map<String, Any>'

### Fix
Convert the built map to `MutableMap`:
```kotlin
... .build().toMutableMap()
